### PR TITLE
AHOYAPPS-489 Update override behavior

### DIFF
--- a/src/commands/rtc/apps/video/deploy.js
+++ b/src/commands/rtc/apps/video/deploy.js
@@ -15,23 +15,18 @@ class DeployCommand extends TwilioClientCommand {
       }
     }
 
-    const appInfo = await getAppInfo.call(this);
+    this.appInfo = await getAppInfo.call(this);
 
-    if (appInfo) {
-      if (this.flags.override) {
-        await this.twilioClient.serverless.services(appInfo.sid).remove();
-        console.log(`Removed app with Passcode: ${appInfo.passcode}`);
-      } else {
-        console.log('A Video app is already deployed. Use the --override flag to override the existing deployment.');
-        await displayAppInfo.call(this);
-        return;
-      }
+    if (this.appInfo && !this.flags.override) {
+      console.log('A Video app is already deployed. Use the --override flag to override the existing deployment.');
+      await displayAppInfo.call(this);
+      return;
     }
     await deploy.call(this);
     await displayAppInfo.call(this);
   }
 }
-
+DeployCommand.appInfo = null;
 DeployCommand.flags = Object.assign(
   {
     'app-directory': flags.string({

--- a/src/commands/rtc/apps/video/deploy.js
+++ b/src/commands/rtc/apps/video/deploy.js
@@ -26,7 +26,6 @@ class DeployCommand extends TwilioClientCommand {
     await displayAppInfo.call(this);
   }
 }
-DeployCommand.appInfo = null;
 DeployCommand.flags = Object.assign(
   {
     'app-directory': flags.string({

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -122,7 +122,7 @@ async function deploy() {
 
   cli.action.start('deploying app');
 
-  const deployOptions = {
+  const baseDeployOptions = {
     env: {
       TWILIO_ACCOUNT_SID: this.twilioClient.accountSid,
       TWILIO_API_KEY_SID: this.twilioClient.username,
@@ -131,7 +131,6 @@ async function deploy() {
       API_PASSCODE_EXPIRY: expiryTime,
     },
     pkgJson: {},
-    serviceName: APP_NAME,
     functionsEnv: 'dev',
     functions: [
       {
@@ -143,6 +142,11 @@ async function deploy() {
     ],
     assets: assets,
   };
+
+  const deployOptionsConfig =
+    this.appInfo && this.appInfo.sid ? { serviceSid: this.appInfo.sid } : { serviceName: APP_NAME };
+
+  const deployOptions = Object.assign({}, baseDeployOptions, deployOptionsConfig);
 
   try {
     await serverlessClient.deployProject(deployOptions);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -145,9 +145,6 @@ async function deploy() {
     assets: assets,
   };
 
-  const deployOptionsConfig =
-    this.appInfo && this.appInfo.sid ? { serviceSid: this.appInfo.sid } : { serviceName: APP_NAME };
-
   if (this.appInfo && this.appInfo.sid) {
     deployOptions.serviceSid = this.appInfo.sid;
   } else {

--- a/test/e2e/e2e.test.js
+++ b/test/e2e/e2e.test.js
@@ -167,6 +167,22 @@ describe('the RTC Twilio-CLI Plugin', () => {
         const { text } = await superagent.get(testWebAppURL + '/login');
         expect(text).toEqual('<html>test</html>');
       });
+
+      it('should redeploy the token server when no app-directory is set and when --override flag is true', async () => {
+        stdout.start();
+        await DeployCommand.run([
+          '--authentication',
+          'passcode',
+          '--override',
+        ]);
+        stdout.stop();
+        const updatedPasscode = getPasscode(stdout.output);
+        const testURL = getURL(stdout.output);
+        const testWebAppURL = getWebAppURL(stdout.output);
+        expect(updatedPasscode).not.toEqual(passcode)
+        expect(testURL).toEqual(URL)
+        superagent.get(`${testWebAppURL}`).catch(e => expect(e.status).toBe(404));
+      });
     });
   });
 

--- a/test/e2e/e2e.test.js
+++ b/test/e2e/e2e.test.js
@@ -148,6 +148,25 @@ describe('the RTC Twilio-CLI Plugin', () => {
         stdout.stop();
         expect(stdout.output).toContain('A Video app is already deployed. Use the --override flag to override the existing deployment.');
       });
+
+      it('should redeploy the app when --override flag is passed', async () => {
+        stdout.start();
+        await DeployCommand.run([
+          '--authentication',
+          'passcode',
+          '--override',
+          '--app-directory',
+          path.join(__dirname, '../test-assets'),
+        ]);
+        stdout.stop();
+        const updatedPasscode = getPasscode(stdout.output);
+        const testURL = getURL(stdout.output);
+        const testWebAppURL = getWebAppURL(stdout.output);
+        expect(updatedPasscode).not.toEqual(passcode)
+        expect(testURL).toEqual(URL)
+        const { text } = await superagent.get(testWebAppURL + '/login');
+        expect(text).toEqual('<html>test</html>');
+      });
     });
   });
 
@@ -213,13 +232,11 @@ describe('the RTC Twilio-CLI Plugin', () => {
         ]);
         stdout.stop();
 
-        // Validate the passcode changed but the URL did not
         const updatedPasscode = getPasscode(stdout.output);
         const testURL = getURL(stdout.output);
         expect(updatedPasscode).not.toEqual(passcode)
         expect(testURL).toEqual(URL)
 
-        // Validate the new passcode can be used to get a token
         const { body } = await superagent
           .post(`${testURL}/token`)
           .send({ passcode: updatedPasscode, room_name: 'test-room', user_identity: 'test user' });

--- a/test/helpers/helpers.test.js
+++ b/test/helpers/helpers.test.js
@@ -98,12 +98,12 @@ describe('the getAssets function', () => {
         content: 'mockHTMLcontent',
       },
       {
-        name: 'index.html',
+        name: '/',
         path: '/',
         content: 'mockHTMLcontent',
       },
       {
-        name: 'index.html',
+        name: '/login',
         path: '/login',
         content: 'mockHTMLcontent',
       },
@@ -161,6 +161,7 @@ describe('the getAppInfo function', () => {
     expect(result).toEqual({
       expiry: 'Wed May 20 2020 18:40:00 GMT+0000',
       hasAssets: false,
+      assets: [],
       passcode: '1234565678',
       sid: 'appSid',
       url: 'https://video-app-5678-dev.twil.io?passcode=1234565678',
@@ -174,6 +175,7 @@ describe('the getAppInfo function', () => {
     expect(result).toEqual({
       expiry: 'Wed May 20 2020 18:40:00 GMT+0000',
       hasAssets: true,
+      assets: [{}],
       passcode: '1234565678',
       sid: 'appSid',
       url: 'https://video-app-5678-dev.twil.io?passcode=1234565678',

--- a/test/helpers/helpers.test.js
+++ b/test/helpers/helpers.test.js
@@ -161,7 +161,6 @@ describe('the getAppInfo function', () => {
     expect(result).toEqual({
       expiry: 'Wed May 20 2020 18:40:00 GMT+0000',
       hasAssets: false,
-      assets: [],
       passcode: '1234565678',
       sid: 'appSid',
       url: 'https://video-app-5678-dev.twil.io?passcode=1234565678',
@@ -175,7 +174,6 @@ describe('the getAppInfo function', () => {
     expect(result).toEqual({
       expiry: 'Wed May 20 2020 18:40:00 GMT+0000',
       hasAssets: true,
-      assets: [{}],
       passcode: '1234565678',
       sid: 'appSid',
       url: 'https://video-app-5678-dev.twil.io?passcode=1234565678',


### PR DESCRIPTION
## Description

These changes address the betterments to the `--override` behavior described in #14.

## Breakdown 

* Specify a `serviceSid` if re-deploying an existing project
* Specify asset SIDs when re-deploying

## Validation

Added 3 new tests to validate the intended behavior.