### PR TITLE
Add api key error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.5
+
+### Maintenance
+
+* Updated `twilio rtc:apps:video:deploy` command so that it checks for the existence of a necessary Twilio API Key before deploying the video token server.
+
 ## 0.1.4
 
 ### Maintenance

--- a/test/helpers/helpers.test.js
+++ b/test/helpers/helpers.test.js
@@ -265,4 +265,29 @@ describe('the deploy function', () => {
     expect(mockDeployProject.mock.calls[0][0].serviceSid).toBe(undefined);
     expect(mockDeployProject.mock.calls[0][0].serviceName).toBe(APP_NAME);
   });
+
+  it('display an error when the and API key is not provided', () => {
+    return expect(
+      deploy.call({
+        twilioClient: {
+          username: 'testAccountSid',
+          password: 'testAuthToken',
+          accountSid: 'testAccountSid',
+        },
+        flags: {},
+      })
+    ).rejects.toMatchInlineSnapshot(`
+[Error: No API Key found.
+
+Please login to the Twilio CLI to create an API key:
+
+twilio login
+
+Alternatively, the Twilio CLI can use credentials stored in these environment variables:
+
+TWILIO_ACCOUNT_SID = your Account SID from twil.io/console
+TWILIO_API_KEY = an API Key created at twil.io/get-api-key
+TWILIO_API_SECRET = the secret for the API Key]
+`);
+  });
 });

--- a/test/helpers/helpers.test.js
+++ b/test/helpers/helpers.test.js
@@ -266,7 +266,7 @@ describe('the deploy function', () => {
     expect(mockDeployProject.mock.calls[0][0].serviceName).toBe(APP_NAME);
   });
 
-  it('display an error when the and API key is not provided', () => {
+  it('should display an error when the API key is not provided', () => {
     return expect(
       deploy.call({
         twilioClient: {


### PR DESCRIPTION
https://issues.corp.twilio.com/browse/AHOYAPPS-601

This PR check to see if an API key is present before deploying the token server. When a user runs `twilio login` and provides their Account SID and Auth Token, the CLI creates an API key and stores it in the keychain. This API Key is deployed with the function to provide video tokens. 

When a user provides their Account SID and Auth Token as environment variables, an API key is not created. A function can still be deployed, but it won't have the correct credentials to mint tokens. This PR prevents that with a useful error message.

Related: https://github.com/twilio/twilio-video-app-react/issues/176

Also, some of our other error messages were not actually being printed to the users console. This PR fixes that by using the `CLIError` object.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
