### PR TITLE
Update plugin to always return room_type parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.0
+
+### Maintenence
+
+- Updated the logic in the video token server so that it always returns the `room_type` parameter.
+- Upgraded @twilio/cli-core from 5.8.1 to 5.9.0
+
 ## 0.3.0
 
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ POST /token
 ```json
 {
   "token": "0000000000000000.0000000000000000000000.00000000000000000",
-  "room_type": "group" | "group-small" | "peer-to-peer" | null
+  "room_type": "group" | "group-small" | "peer-to-peer"
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@twilio-labs/plugin-rtc",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twilio-labs/plugin-rtc",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "A Twilio-CLI plugin for real-time communication apps",
   "main": "index.js",
   "publishConfig": {

--- a/src/video-token-server.js
+++ b/src/video-token-server.js
@@ -94,6 +94,6 @@ module.exports.handler = async (context, event, callback) => {
   const videoGrant = new VideoGrant({ room: room_name });
   token.addGrant(videoGrant);
   response.setStatusCode(200);
-  response.setBody({ token: token.toJwt(), room_type: create_room ? ROOM_TYPE : null });
+  response.setBody({ token: token.toJwt(), room_type: ROOM_TYPE });
   return callback(null, response);
 };

--- a/test/e2e/e2e.test.js
+++ b/test/e2e/e2e.test.js
@@ -147,7 +147,7 @@ describe('the RTC Twilio-CLI Plugin', () => {
           .post(`${URL}/token`)
           .send({ passcode, room_name: ROOM_NAME, user_identity: 'test user', create_room: false });
         expect(jwt.decode(body.token).grants).toEqual({ identity: 'test user', video: { room: ROOM_NAME } });
-        expect(body.room_type).toEqual(null);
+        expect(body.room_type).toEqual('group');
 
         try {
           await twilioClient.video.rooms(ROOM_NAME).fetch();

--- a/test/video-token-server.test.js
+++ b/test/video-token-server.test.js
@@ -185,7 +185,7 @@ describe('the video-token-server', () => {
 
       expect(mockCreateFunction).not.toHaveBeenCalled();
       expect(callback).toHaveBeenCalledWith(null, {
-        body: { token: expect.any(String), room_type: null },
+        body: { token: expect.any(String), room_type: 'group' },
         headers: { 'Content-Type': 'application/json' },
         statusCode: 200,
       });


### PR DESCRIPTION
<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

This PR adjust the logic in the token server so that it returns the `room_type` parameter even when `create_room` is false. 
