### PR TITLE
Video 3729 add conversations support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.8.0
+
+### New Features
+
+- Added support for Twilio Conversations. When an application requests a token from the `/token` endpoint, a `create_conversation=true` parameter can now be specified. When this parameter is present, the `/token` endpoint will create a conversation that is associated with the room and add the participant to it. This allows video application to use Twilio Conversations for in-room chat.
+
+### Maintenence
+
+- Upgraded @twilio/cli-core from 5.15.1 to 5.17.0
+- Upgraded lodash from 4.17.20 to 4.17.21
+
 ## 0.7.1
 
 ### Maintenence

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
-- Added support for Twilio Conversations. When an application requests a token from the `/token` endpoint, a `create_conversation=true` parameter can now be specified. When this parameter is present, the `/token` endpoint will create a conversation that is associated with the room and add the participant to it. This allows video application to use Twilio Conversations for in-room chat.
+- Added support for Twilio Conversations. When an application requests a token from the `/token` endpoint, a `create_conversation=true` parameter can now be specified. When this parameter is present, the `/token` endpoint will create a conversation that is associated with the room and add the participant to it. This allows video application to use [Twilio Conversations](https://www.twilio.com/conversations-api) for in-room chat.
 
 ### Maintenence
 

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 Twilio Inc.
+   Copyright 2021 Twilio Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Each request is verified using a passcode generated at deploy time. Passcodes re
 
 ### Token
 
-Returns a Programmable Video Access token.
+This endpoint returns a Programmable Video Access token. When `create_room` is true, it will create a room and [Twilio conversation](https://www.twilio.com/docs/conversations/api/conversation-resource) associated with the room. This token is used by the above mentioned Video Apps to connect to a video room and a conversation.
 
 ```shell
 POST /token
@@ -94,7 +94,7 @@ POST /token
 | --------------- | --------- | -------------------------------------------------------------------------------------- |
 | `passcode`      | `string`  | **Required**. The application passcode.                                                |
 | `user_identity` | `string`  | **Required**. The user's identity.                                                     |
-| `room_name`     | `string`  | A room name that will be used to create a token scoped to connecting to only one room. |
+| `room_name`     | `string`  | **Required when `create_room` is `true`** A room name that will be used to create a token scoped to connecting to only one room. |
 | `create_room`   | `boolean` | (default: `true`) When false, a room will not be created when a token is requested.    |
 
 #### Success Responses

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Each request is verified using a passcode generated at deploy time. Passcodes re
 
 ### Token
 
-This endpoint returns a Programmable Video Access token. When `create_room` is true, it will create a room and [Twilio conversation](https://www.twilio.com/docs/conversations/api/conversation-resource) associated with the room. This token is used by the above mentioned Video Apps to connect to a video room and a conversation.
+This endpoint returns a Programmable Video Access token. When `create_room` is true, it will create a room, and when `create_conversation` is true, it will create a [Twilio conversation](https://www.twilio.com/docs/conversations/api/conversation-resource) associated with the room. This token is used by the above mentioned Video Apps to connect to a video room and a conversation.
 
 ```shell
 POST /token
@@ -90,12 +90,13 @@ POST /token
 
 #### Parameters
 
-| Name            | Type      | Description                                                                            |
-| --------------- | --------- | -------------------------------------------------------------------------------------- |
-| `passcode`      | `string`  | **Required**. The application passcode.                                                |
-| `user_identity` | `string`  | **Required**. The user's identity.                                                     |
-| `room_name`     | `string`  | **Required when `create_room` is `true`** A room name that will be used to create a token scoped to connecting to only one room. |
-| `create_room`   | `boolean` | (default: `true`) When false, a room will not be created when a token is requested.    |
+| Name                  | Type      | Description                                                                            |
+| --------------------- | --------- | -------------------------------------------------------------------------------------- |
+| `passcode`            | `string`  | **Required**. The application passcode.                                                |
+| `user_identity`       | `string`  | **Required**. The user's identity.                                                     |
+| `room_name`           | `string`  | **Required when `create_room` is `true`** A room name that will be used to create a token scoped to connecting to only one room. |
+| `create_room`         | `boolean` | (default: `true`) When false, a room will not be created when a token is requested.    |
+| `create_conversation` | `boolean` | (default: `false`) When true, a Twilio Conversation will be created (if it doesn't already exist) and a participant will be added to it when a token is requested. `create_room` must also be `true`.   |
 
 #### Success Responses
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Each request is verified using a passcode generated at deploy time. Passcodes re
 
 ### Token
 
-This endpoint returns a Programmable Video Access token. When `create_room` is true, it will create a room, and when `create_conversation` is true, it will create a [Twilio conversation](https://www.twilio.com/docs/conversations/api/conversation-resource) associated with the room. This token is used by the above mentioned Video Apps to connect to a video room and a conversation.
+This endpoint returns a Programmable Video Access token. When `create_room` is true, it will create a room, and when `create_conversation` is true, it will create a [Twilio Conversation](https://www.twilio.com/docs/conversations/api/conversation-resource) associated with the room. This token is used by the above mentioned Video Apps to connect to a video room and a conversation.
 
 ```shell
 POST /token
@@ -96,7 +96,7 @@ POST /token
 | `user_identity`       | `string`  | **Required**. The user's identity.                                                     |
 | `room_name`           | `string`  | **Required when `create_room` is `true`** A room name that will be used to create a token scoped to connecting to only one room. |
 | `create_room`         | `boolean` | (default: `true`) When false, a room will not be created when a token is requested.    |
-| `create_conversation` | `boolean` | (default: `false`) When true, a Twilio Conversation will be created (if it doesn't already exist) and a participant will be added to it when a token is requested. `create_room` must also be `true`.   |
+| `create_conversation` | `boolean` | (default: `false`) When true, a [Twilio Conversation](https://www.twilio.com/docs/conversations/api/conversation-resource) will be created (if it doesn't already exist) and a participant will be added to it when a token is requested. `create_room` must also be `true`.   |
 
 #### Success Responses
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@twilio-labs/plugin-rtc",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twilio-labs/plugin-rtc",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "A Twilio-CLI plugin for real-time communication apps",
   "main": "index.js",
   "publishConfig": {

--- a/src/commands/rtc/apps/video/delete.js
+++ b/src/commands/rtc/apps/video/delete.js
@@ -1,13 +1,17 @@
-const { findApp } = require('../../../../helpers');
+const { findApp, findConversationsService } = require('../../../../helpers');
 const { TwilioClientCommand } = require('@twilio/cli-core').baseCommands;
 
 class DeleteCommand extends TwilioClientCommand {
   async run() {
     await super.run();
     const appInfo = await findApp.call(this);
+    const conversatsionsServiceInfo = await findConversationsService.call(this);
 
     if (appInfo) {
       await this.twilioClient.serverless.services(appInfo.sid).remove();
+      if (conversatsionsServiceInfo) {
+        await this.twilioClient.conversations.services(conversatsionsServiceInfo.sid).remove();
+      }
       console.log('Successfully deleted app.');
     } else {
       console.log('There is no app to delete.');

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -156,7 +156,7 @@ async function getConversationsServiceSID() {
   }
 
   const service = await this.twilioClient.conversations.services.create({
-    friendlyName: `${APP_NAME}-conversation-service`,
+    friendlyName: `${APP_NAME}-conversations-service`,
   });
   return service.sid;
 }
@@ -208,7 +208,7 @@ TWILIO_API_SECRET = the secret for the API Key`);
       API_PASSCODE: pin,
       API_PASSCODE_EXPIRY: expiryTime,
       ROOM_TYPE: this.flags['room-type'],
-      CHAT_SERVICE_SID: conversationServiceSid,
+      CONVERSATIONS_SERVICE_SID: conversationServiceSid,
     },
     pkgJson: {
       dependencies: {

--- a/src/serverless/functions/token.js
+++ b/src/serverless/functions/token.js
@@ -63,7 +63,6 @@ module.exports.handler = async (context, event, callback) => {
 
   if (create_room) {
     const client = context.getTwilioClient();
-    const conversationsClient = client.conversations.services(CONVERSATIONS_SERVICE_SID);
     let room;
 
     try {
@@ -86,6 +85,8 @@ module.exports.handler = async (context, event, callback) => {
     }
 
     if (create_conversation) {
+      const conversationsClient = client.conversations.services(CONVERSATIONS_SERVICE_SID);
+
       try {
         // See if conversation already exists
         await conversationsClient.conversations(room.sid).fetch();

--- a/src/serverless/functions/token.js
+++ b/src/serverless/functions/token.js
@@ -53,7 +53,7 @@ module.exports.handler = async (context, event, callback) => {
   if (create_room) {
     const client = context.getTwilioClient();
     const conversationsClient = client.conversations.services(CONVERSATIONS_SERVICE_SID);
-    let room, conversation;
+    let room;
 
     try {
       // See if a room already exists
@@ -76,11 +76,11 @@ module.exports.handler = async (context, event, callback) => {
 
     try {
       // See if conversation already exists
-      conversation = await conversationsClient.conversations(room.sid).fetch();
+      await conversationsClient.conversations(room.sid).fetch();
     } catch (e) {
       try {
         // If conversation doesn't exist, create it.
-        conversation = await conversationsClient.conversations.create({ uniqueName: room.sid });
+        await conversationsClient.conversations.create({ uniqueName: room.sid });
       } catch (e) {
         response.setStatusCode(500);
         response.setBody({

--- a/src/serverless/functions/token.js
+++ b/src/serverless/functions/token.js
@@ -39,14 +39,30 @@ module.exports.handler = async (context, event, callback) => {
     return callback(null, response);
   }
 
+  if (!room_name && create_room) {
+    response.setStatusCode(400);
+    response.setBody({
+      error: {
+        message: 'missing room_name',
+        explanation: 'The room_name parameter is missing. room_name is required when create_room is true.',
+      },
+    });
+    return callback(null, response);
+  }
+
   if (create_room) {
     const client = context.getTwilioClient();
+    const conversationsClient = client.conversations.services(CONVERSATIONS_SERVICE_SID);
+    let room, conversation;
 
     try {
-      await client.video.rooms.create({ uniqueName: room_name, type: ROOM_TYPE });
+      // See if a room already exists
+      room = await client.video.rooms(room_name).fetch();
     } catch (e) {
-      // Ignore 53113 error (room already exists). See: https://www.twilio.com/docs/api/errors/53113
-      if (e.code !== 53113) {
+      try {
+        // If room doesn't exist, create it
+        room = await client.video.rooms.create({ uniqueName: room_name, type: ROOM_TYPE });
+      } catch (e) {
         response.setStatusCode(500);
         response.setBody({
           error: {
@@ -57,16 +73,61 @@ module.exports.handler = async (context, event, callback) => {
         return callback(null, response);
       }
     }
+
+    try {
+      // See if conversation already exists
+      conversation = await conversationsClient.conversations(room.sid).fetch();
+    } catch (e) {
+      try {
+        // If conversation doesn't exist, create it.
+        conversation = await conversationsClient.conversations.create({ uniqueName: room.sid });
+      } catch (e) {
+        response.setStatusCode(500);
+        response.setBody({
+          error: {
+            message: 'error creating conversation',
+            explanation: 'Something went wrong when creating a conversation.',
+          },
+        });
+        return callback(null, response);
+      }
+    }
+
+    try {
+      // Add participant to conversation
+      await conversationsClient.conversations(room.sid).participants.create({ identity: user_identity });
+    } catch (e) {
+      // Ignore "Participant already exists" error (50433)
+      if (e.code !== 50433) {
+        response.setStatusCode(500);
+        response.setBody({
+          error: {
+            message: 'error creating conversation participant',
+            explanation: 'Something went wrong when creating a conversation participant.',
+          },
+        });
+        return callback(null, response);
+      }
+    }
   }
 
+  // Create token
   const token = new AccessToken(ACCOUNT_SID, TWILIO_API_KEY_SID, TWILIO_API_KEY_SECRET, {
     ttl: MAX_ALLOWED_SESSION_DURATION,
   });
+
+  // Add participant's identity to token
   token.identity = user_identity;
+
+  // Add video grant to token
   const videoGrant = new VideoGrant({ room: room_name });
-  const chatGrant = new ChatGrant({ serviceSid: CONVERSATIONS_SERVICE_SID });
   token.addGrant(videoGrant);
+
+  // Add chat grant to token
+  const chatGrant = new ChatGrant({ serviceSid: CONVERSATIONS_SERVICE_SID });
   token.addGrant(chatGrant);
+
+  // Return token
   response.setStatusCode(200);
   response.setBody({ token: token.toJwt(), room_type: ROOM_TYPE });
   return callback(null, response);

--- a/src/serverless/functions/token.js
+++ b/src/serverless/functions/token.js
@@ -3,10 +3,11 @@
 
 const AccessToken = Twilio.jwt.AccessToken;
 const VideoGrant = AccessToken.VideoGrant;
+const ChatGrant = AccessToken.ChatGrant;
 const MAX_ALLOWED_SESSION_DURATION = 14400;
 
 module.exports.handler = async (context, event, callback) => {
-  const { ACCOUNT_SID, TWILIO_API_KEY_SID, TWILIO_API_KEY_SECRET, ROOM_TYPE } = context;
+  const { ACCOUNT_SID, TWILIO_API_KEY_SID, TWILIO_API_KEY_SECRET, ROOM_TYPE, CHAT_SERVICE_SID } = context;
 
   const authHandler = require(Runtime.getAssets()['/auth-handler.js'].path);
   authHandler(context, event, callback);
@@ -63,7 +64,9 @@ module.exports.handler = async (context, event, callback) => {
   });
   token.identity = user_identity;
   const videoGrant = new VideoGrant({ room: room_name });
+  const chatGrant = new ChatGrant({ serviceSid: CHAT_SERVICE_SID });
   token.addGrant(videoGrant);
+  token.addGrant(chatGrant);
   response.setStatusCode(200);
   response.setBody({ token: token.toJwt(), room_type: ROOM_TYPE });
   return callback(null, response);

--- a/src/serverless/functions/token.js
+++ b/src/serverless/functions/token.js
@@ -7,7 +7,7 @@ const ChatGrant = AccessToken.ChatGrant;
 const MAX_ALLOWED_SESSION_DURATION = 14400;
 
 module.exports.handler = async (context, event, callback) => {
-  const { ACCOUNT_SID, TWILIO_API_KEY_SID, TWILIO_API_KEY_SECRET, ROOM_TYPE, CHAT_SERVICE_SID } = context;
+  const { ACCOUNT_SID, TWILIO_API_KEY_SID, TWILIO_API_KEY_SECRET, ROOM_TYPE, CONVERSATIONS_SERVICE_SID } = context;
 
   const authHandler = require(Runtime.getAssets()['/auth-handler.js'].path);
   authHandler(context, event, callback);
@@ -64,7 +64,7 @@ module.exports.handler = async (context, event, callback) => {
   });
   token.identity = user_identity;
   const videoGrant = new VideoGrant({ room: room_name });
-  const chatGrant = new ChatGrant({ serviceSid: CHAT_SERVICE_SID });
+  const chatGrant = new ChatGrant({ serviceSid: CONVERSATIONS_SERVICE_SID });
   token.addGrant(videoGrant);
   token.addGrant(chatGrant);
   response.setStatusCode(200);

--- a/test/e2e/e2e.test.js
+++ b/test/e2e/e2e.test.js
@@ -133,11 +133,29 @@ describe('the RTC Twilio-CLI Plugin', () => {
         const { body } = await superagent
           .post(`${URL}/token`)
           .send({ passcode, room_name: ROOM_NAME, user_identity: 'test user' });
-        expect(jwt.decode(body.token).grants).toEqual({ identity: 'test user', video: { room: ROOM_NAME } });
+        expect(jwt.decode(body.token).grants).toEqual(
+          expect.objectContaining({ identity: 'test user', video: { room: ROOM_NAME } })
+        );
         expect(body.room_type).toEqual('group');
 
         const room = await twilioClient.video.rooms(ROOM_NAME).fetch();
         expect(room.type).toEqual('group');
+      });
+
+      it('should return a video token with a valid Chat Grant', async () => {
+        const ROOM_NAME = nanoid();
+        const { body } = await superagent
+          .post(`${URL}/token`)
+          .send({ passcode, room_name: ROOM_NAME, user_identity: 'test user' });
+
+        const conversationServiceSid = jwt.decode(body.token).grants.chat.service_sid;
+
+        const deployedConversationsServices = await twilioClient.conversations.services.list();
+        const deployedConversationsService = deployedConversationsServices.find(
+          service => (service.sid = conversationServiceSid)
+        );
+
+        expect(deployedConversationsService).toBeDefined();
       });
 
       it('should return a video token without creating a room when the "create_room" flag is false', async () => {
@@ -146,7 +164,9 @@ describe('the RTC Twilio-CLI Plugin', () => {
         const { body } = await superagent
           .post(`${URL}/token`)
           .send({ passcode, room_name: ROOM_NAME, user_identity: 'test user', create_room: false });
-        expect(jwt.decode(body.token).grants).toEqual({ identity: 'test user', video: { room: ROOM_NAME } });
+        expect(jwt.decode(body.token).grants).toEqual(
+          expect.objectContaining({ identity: 'test user', video: { room: ROOM_NAME } })
+        );
         expect(body.room_type).toEqual('group');
 
         try {
@@ -261,7 +281,9 @@ describe('the RTC Twilio-CLI Plugin', () => {
         const { body } = await superagent
           .post(`${URL}/token`)
           .send({ passcode, room_name: ROOM_NAME, user_identity: 'test user' });
-        expect(jwt.decode(body.token).grants).toEqual({ identity: 'test user', video: { room: ROOM_NAME } });
+        expect(jwt.decode(body.token).grants).toEqual(
+          expect.objectContaining({ identity: 'test user', video: { room: ROOM_NAME } })
+        );
         expect(body.room_type).toEqual('go');
 
         const room = await twilioClient.video.rooms(ROOM_NAME).fetch();
@@ -298,7 +320,9 @@ describe('the RTC Twilio-CLI Plugin', () => {
         const { body } = await superagent
           .post(`${testURL}/token`)
           .send({ passcode: updatedPasscode, room_name: 'test-room', user_identity: 'test user' });
-        expect(jwt.decode(body.token).grants).toEqual({ identity: 'test user', video: { room: 'test-room' } });
+        expect(jwt.decode(body.token).grants).toEqual(
+          expect.objectContaining({ identity: 'test user', video: { room: 'test-room' } })
+        );
       });
     });
   });

--- a/test/e2e/e2e.test.js
+++ b/test/e2e/e2e.test.js
@@ -142,7 +142,7 @@ describe('the RTC Twilio-CLI Plugin', () => {
         expect(room.type).toEqual('group');
       });
 
-      it('should return a video token with a valid Chat Grant', async () => {
+      it('should return a video token with a valid Chat Grant and add the participant to the conversation', async () => {
         const ROOM_NAME = nanoid();
         const { body } = await superagent
           .post(`${URL}/token`)
@@ -155,7 +155,16 @@ describe('the RTC Twilio-CLI Plugin', () => {
           service => (service.sid = conversationServiceSid)
         );
 
+        const conversationParticipants = await twilioClient.conversations
+          .conversations(conversationServiceSid)
+          .participants.list();
+
+        const conversationParticipant = conversationParticipants.find(
+          participant => participant.identity === 'test user'
+        );
+
         expect(deployedConversationsService).toBeDefined();
+        expect(conversationParticipant).toBeDefined();
       });
 
       it('should return a video token without creating a room when the "create_room" flag is false', async () => {

--- a/test/e2e/e2e.test.js
+++ b/test/e2e/e2e.test.js
@@ -158,22 +158,16 @@ describe('the RTC Twilio-CLI Plugin', () => {
           service => (service.sid = conversationServiceSid)
         );
 
-        // Find the conversation
-        const conversation = await twilioClient.conversations
+        // Find the conversation participant
+        const conversationParticipants = await twilioClient.conversations
           .services(deployedConversationsService.sid)
           .conversations(room.sid)
-          .fetch();
-
-        // Find the participant that has been added to the conversation
-        const conversationParticipants = await twilioClient.conversations
-          .conversations(conversation.sid)
           .participants.list();
         const conversationParticipant = conversationParticipants.find(
           participant => participant.identity === 'test user'
         );
 
         expect(deployedConversationsService).toBeDefined();
-        expect(conversation).toBeDefined();
         expect(conversationParticipant).toBeDefined();
       });
 

--- a/test/e2e/e2e.test.js
+++ b/test/e2e/e2e.test.js
@@ -150,20 +150,30 @@ describe('the RTC Twilio-CLI Plugin', () => {
 
         const conversationServiceSid = jwt.decode(body.token).grants.chat.service_sid;
 
+        const room = await twilioClient.video.rooms(ROOM_NAME).fetch();
+
+        // Find the deployed conversations service
         const deployedConversationsServices = await twilioClient.conversations.services.list();
         const deployedConversationsService = deployedConversationsServices.find(
           service => (service.sid = conversationServiceSid)
         );
 
-        const conversationParticipants = await twilioClient.conversations
-          .conversations(conversationServiceSid)
-          .participants.list();
+        // Find the conversation
+        const conversation = await twilioClient.conversations
+          .services(deployedConversationsService.sid)
+          .conversations(room.sid)
+          .fetch();
 
+        // Find the participant that has been added to the conversation
+        const conversationParticipants = await twilioClient.conversations
+          .conversations(conversation.sid)
+          .participants.list();
         const conversationParticipant = conversationParticipants.find(
           participant => participant.identity === 'test user'
         );
 
         expect(deployedConversationsService).toBeDefined();
+        expect(conversation).toBeDefined();
         expect(conversationParticipant).toBeDefined();
       });
 

--- a/test/helpers/helpers.test.js
+++ b/test/helpers/helpers.test.js
@@ -327,7 +327,7 @@ describe('the deploy function', () => {
     expect(mockDeployProject.mock.calls[0][0].env.CHAT_SERVICE_SID).toBe('newMockConversationsServiceSid');
   });
 
-  it('should create a new conversations service when one does not already exist', async () => {
+  it('should use an existing conversations service when one already exists', async () => {
     await deploy.call({
       twilioClient: getMockTwilioInstance({ username: '', password: '', conversationsServiceExists: true }),
       flags: {},

--- a/test/helpers/helpers.test.js
+++ b/test/helpers/helpers.test.js
@@ -324,7 +324,7 @@ describe('the deploy function', () => {
       flags: {},
     });
 
-    expect(mockDeployProject.mock.calls[0][0].env.CHAT_SERVICE_SID).toBe('newMockConversationsServiceSid');
+    expect(mockDeployProject.mock.calls[0][0].env.CONVERSATIONS_SERVICE_SID).toBe('newMockConversationsServiceSid');
   });
 
   it('should use an existing conversations service when one already exists', async () => {
@@ -333,7 +333,7 @@ describe('the deploy function', () => {
       flags: {},
     });
 
-    expect(mockDeployProject.mock.calls[0][0].env.CHAT_SERVICE_SID).toBe('mockConversationsServiceSID');
+    expect(mockDeployProject.mock.calls[0][0].env.CONVERSATIONS_SERVICE_SID).toBe('mockConversationsServiceSID');
   });
 
   it('should set ui-editable to false when the flag is false', async () => {

--- a/test/serverless/functions/token.test.js
+++ b/test/serverless/functions/token.test.js
@@ -14,7 +14,7 @@ const mockContext = {
   ACCOUNT_SID: 'AC1234',
   TWILIO_API_KEY_SID: 'SK1234',
   TWILIO_API_KEY_SECRET: 'api_secret',
-  CHAT_SERVICE_SID: 'MockServiceSid',
+  CONVERSATIONS_SERVICE_SID: 'MockServiceSid',
   ROOM_TYPE: 'group',
   getTwilioClient: () => mockTwilioClient,
 };

--- a/test/serverless/functions/token.test.js
+++ b/test/serverless/functions/token.test.js
@@ -14,6 +14,7 @@ const mockContext = {
   ACCOUNT_SID: 'AC1234',
   TWILIO_API_KEY_SID: 'SK1234',
   TWILIO_API_KEY_SECRET: 'api_secret',
+  CHAT_SERVICE_SID: 'MockServiceSid',
   ROOM_TYPE: 'group',
   getTwilioClient: () => mockTwilioClient,
 };
@@ -67,6 +68,9 @@ describe('the video-token-server', () => {
       grants: {
         identity: 'test identity',
         video: {},
+        chat: {
+          service_sid: 'MockServiceSid',
+        },
       },
       iat: 0,
       iss: 'SK1234',
@@ -91,6 +95,9 @@ describe('the video-token-server', () => {
           identity: 'test-user',
           video: {
             room: 'test-room',
+          },
+          chat: {
+            service_sid: 'MockServiceSid',
           },
         },
         iat: 0,

--- a/test/serverless/functions/token.test.js
+++ b/test/serverless/functions/token.test.js
@@ -170,7 +170,7 @@ describe('the video-token-server', () => {
   it('should create a conversations client with the correct conversations service', async () => {
     await handler(
       mockContext,
-      { passcode: '12345612345678', room_name: 'test-room', user_identity: 'test-user' },
+      { passcode: '12345612345678', room_name: 'test-room', user_identity: 'test-user', create_conversation: true },
       callback
     );
 

--- a/test/serverless/functions/token.test.js
+++ b/test/serverless/functions/token.test.js
@@ -54,7 +54,7 @@ describe('the video-token-server', () => {
     it('should create a new room and conversation, then return a valid token', async () => {
       await handler(
         mockContext,
-        { passcode: '12345612345678', room_name: 'test-room', user_identity: 'test-user' },
+        { passcode: '12345612345678', room_name: 'test-room', user_identity: 'test-user', create_conversation: true },
         callback
       );
 
@@ -93,7 +93,7 @@ describe('the video-token-server', () => {
 
       await handler(
         mockContext,
-        { passcode: '12345612345678', room_name: 'test-room', user_identity: 'test-user' },
+        { passcode: '12345612345678', room_name: 'test-room', user_identity: 'test-user', create_conversation: true },
         callback
       );
 
@@ -114,7 +114,7 @@ describe('the video-token-server', () => {
     it('should fetch the existing room and conversation, then return a valid token', async () => {
       await handler(
         mockContext,
-        { passcode: '12345612345678', room_name: 'test-room', user_identity: 'test-user' },
+        { passcode: '12345612345678', room_name: 'test-room', user_identity: 'test-user', create_conversation: true },
         callback
       );
 
@@ -135,7 +135,7 @@ describe('the video-token-server', () => {
 
     await handler(
       mockContext,
-      { passcode: '12345612345678', room_name: 'test-room', user_identity: 'test-user' },
+      { passcode: '12345612345678', room_name: 'test-room', user_identity: 'test-user', create_conversation: true },
       callback
     );
 
@@ -156,7 +156,7 @@ describe('the video-token-server', () => {
 
     await handler(
       mockContext,
-      { passcode: '12345612345678', room_name: 'test-room', user_identity: 'test-user' },
+      { passcode: '12345612345678', room_name: 'test-room', user_identity: 'test-user', create_conversation: true },
       callback
     );
 
@@ -185,6 +185,21 @@ describe('the video-token-server', () => {
         error: {
           message: 'invalid parameter',
           explanation: 'A boolean value must be provided for the create_room parameter',
+        },
+      },
+      headers: { 'Content-Type': 'application/json' },
+      statusCode: 400,
+    });
+  });
+
+  it('should return an "invalid parameter" error when the create_conversation parameter is not a boolean', async () => {
+    await handler(mockContext, { user_identity: 'test identity', create_conversation: 'no thanks' }, callback);
+
+    expect(callback).toHaveBeenCalledWith(null, {
+      body: {
+        error: {
+          message: 'invalid parameter',
+          explanation: 'A boolean value must be provided for the create_conversation parameter',
         },
       },
       headers: { 'Content-Type': 'application/json' },
@@ -299,6 +314,23 @@ describe('the video-token-server', () => {
       );
 
       expect(mockFns.createRoom).not.toHaveBeenCalled();
+      expect(callback).toHaveBeenCalledWith(null, {
+        body: { token: expect.any(String), room_type: 'group' },
+        headers: { 'Content-Type': 'application/json' },
+        statusCode: 200,
+      });
+    });
+
+    it('should return a valid token without creating a conversation when "create_conversation" is false', async () => {
+      await handler(
+        mockContext,
+        { passcode: '12345612345678', room_name: 'test-room', user_identity: 'test-user', create_conversation: false },
+        callback
+      );
+
+      expect(mockFns.fetchConversation).not.toHaveBeenCalled();
+      expect(mockFns.createConversation).not.toHaveBeenCalled();
+      expect(mockFns.createParticipant).not.toHaveBeenCalled();
       expect(callback).toHaveBeenCalledWith(null, {
         body: { token: expect.any(String), room_type: 'group' },
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.


This PR adds support for the new Conversations feature:

- Then the "deploy" command is run, a new conversations service will be created (unless one already exists, like when the --override flag is used). 
- The SID of the conversations service is stored as an environment variable. This SID is used to create a Chat Grant on the token that is returned by `/token`
- When a token is requested from the `/token` endpoint (and when `create_room` is `true`), a video room and Twilio conversation will be created, and the participant's identity will be added to the conversation. The returned token can be used to connect to the Video SDK and the Conversations SDK. 
- The conversations service will be deleted when the "delete" command is run.

Readme updates can be seen here: https://github.com/twilio-labs/plugin-rtc/blob/VIDEO-3729-add-conversations-support/README.md
