### PR TITLE
Add conversations timers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.8.1
+
+### Enhancement
+
+- Specified a timer when creating a Twilio Conversation. This will automatically close the conversation after 24 hours, which is equal to the maximum duration of a video room. This helps to clean up old conversations since there is a limit that a single participant can not be added to more than 1,000 open conversations.
+
 ## 0.8.0
 
 ### New Features

--- a/src/serverless/functions/token.js
+++ b/src/serverless/functions/token.js
@@ -93,7 +93,10 @@ module.exports.handler = async (context, event, callback) => {
       } catch (e) {
         try {
           // If conversation doesn't exist, create it.
-          await conversationsClient.conversations.create({ uniqueName: room.sid });
+          // Here we add a timer to close the conversation after the maximum length of a room (24 hours).
+          // This helps to clean up old conversations since there is a limit that a single participant
+          // can not be added to more than 1,000 open conversations.
+          await conversationsClient.conversations.create({ uniqueName: room.sid, 'timers.close': 'P1D' });
         } catch (e) {
           response.setStatusCode(500);
           response.setBody({

--- a/src/serverless/functions/token.js
+++ b/src/serverless/functions/token.js
@@ -96,7 +96,7 @@ module.exports.handler = async (context, event, callback) => {
           // Here we add a timer to close the conversation after the maximum length of a room (24 hours).
           // This helps to clean up old conversations since there is a limit that a single participant
           // can not be added to more than 1,000 open conversations.
-          await conversationsClient.conversations.create({ uniqueName: room.sid, 'timers.close': 'P1D' });
+          await conversationsClient.conversations.create({ uniqueName: room.sid, 'timers.closed': 'P1D' });
         } catch (e) {
           response.setStatusCode(500);
           response.setBody({

--- a/test/serverless/functions/token.test.js
+++ b/test/serverless/functions/token.test.js
@@ -59,7 +59,7 @@ describe('the video-token-server', () => {
       );
 
       expect(mockFns.createRoom).toHaveBeenCalledWith({ type: 'group', uniqueName: 'test-room' });
-      expect(mockFns.createConversation).toHaveBeenCalledWith({ uniqueName: 'mockNewRoomSid' });
+      expect(mockFns.createConversation).toHaveBeenCalledWith({ uniqueName: 'mockNewRoomSid', 'timers.closed': 'P1D' });
       expect(callback).toHaveBeenCalledWith(null, {
         body: { token: expect.any(String), room_type: 'group' },
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.


- [x] I acknowledge that all my contributions will be made under the project's license.

This PR simply adds a conversations timer so that a conversation will automatically be closed after 24 hours, which is equal to the maximum duration of a room. This helps to clean up old conversations since there is a limit that a single participant can not be added to more than 1,000 open conversations.

The timers don't show up in the Twilio Console, but I was able to verify that this function works correctly by verifying the conversation details with the Twilio API:

![image](https://user-images.githubusercontent.com/12685223/113067498-acbbef00-9179-11eb-81f2-f81e4e005a92.png)
