### PR TITLE
Use default twilio client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.8.2
+
+### Maintenence
+
+- The [recording rules function](https://github.com/twilio-labs/plugin-rtc/blob/master/src/serverless/functions/recordingrules.js) now uses the Twilio client returned by `context.getTwilioClient()`.
+
 ## 0.8.1
 
 ### Enhancement

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -212,7 +212,7 @@ TWILIO_API_SECRET = the secret for the API Key`);
     },
     pkgJson: {
       dependencies: {
-        twilio: '^3.54.2',
+        twilio: '^3.60.0', // This determines the version of the Twilio client returned by context.getTwilioClient()
       },
     },
     functionsEnv: 'dev',

--- a/src/serverless/functions/recordingrules.js
+++ b/src/serverless/functions/recordingrules.js
@@ -1,11 +1,6 @@
 /* global Twilio Runtime */
 'use strict';
 
-// We need to use a newer twilio client than the one provided by context.getTwilioClient(),
-// so we require it here. The version is specified in helpers.js in the 'deployOptions' object.
-// TODO: replace with context.getTwilioClient() when https://issues.corp.twilio.com/browse/RUN-3731 is complete
-const twilio = require('twilio');
-
 module.exports.handler = async (context, event, callback) => {
   const authHandler = require(Runtime.getAssets()['/auth-handler.js'].path);
   authHandler(context, event, callback);
@@ -37,7 +32,7 @@ module.exports.handler = async (context, event, callback) => {
     return callback(null, response);
   }
 
-  const client = twilio(context.ACCOUNT_SID, context.AUTH_TOKEN);
+  const client = context.getTwilioClient();
 
   try {
     const recordingRulesResponse = await client.video.rooms(room_sid).recordingRules.update({ rules });

--- a/test/serverless/functions/recordingrules.test.js
+++ b/test/serverless/functions/recordingrules.test.js
@@ -13,6 +13,12 @@ const mockClient = jest.fn(() => ({
   },
 }));
 
+const mockContext = {
+  ACCOUNT_SID: '1234',
+  AUTH_TOKEN: '2345',
+  getTwilioClient: () => mockClient(),
+};
+
 jest.mock('twilio');
 twilio.mockImplementation(mockClient);
 
@@ -20,13 +26,8 @@ describe('the recordingrules function', () => {
   it('should correctly respond when a room update is successful', async () => {
     const mockCallback = jest.fn();
 
-    await handler(
-      { ACCOUNT_SID: '1234', AUTH_TOKEN: '2345' },
-      { room_sid: 'mockRoomSid', rules: 'mockRules' },
-      mockCallback
-    );
+    await handler(mockContext, { room_sid: 'mockRoomSid', rules: 'mockRules' }, mockCallback);
 
-    expect(mockClient).toHaveBeenCalledWith('1234', '2345');
     expect(mockCallback).toHaveBeenCalledWith(null, {
       body: 'mockSuccessResponse',
       headers: { 'Content-Type': 'application/json' },
@@ -39,11 +40,7 @@ describe('the recordingrules function', () => {
     const mockError = { message: 'mockErrorMesage', code: 123 };
     mockUpdateFn.mockImplementationOnce(() => Promise.reject(mockError));
 
-    await handler(
-      { ACCOUNT_SID: '1234', AUTH_TOKEN: '2345' },
-      { room_sid: 'mockRoomSid', rules: 'mockRules' },
-      mockCallback
-    );
+    await handler(mockContext, { room_sid: 'mockRoomSid', rules: 'mockRules' }, mockCallback);
 
     expect(mockCallback).toHaveBeenCalledWith(null, {
       body: { error: mockError },
@@ -55,7 +52,7 @@ describe('the recordingrules function', () => {
   it('should return a "missing room_sid" error when the room_sid is absent', async () => {
     const mockCallback = jest.fn();
 
-    await handler({ ACCOUNT_SID: '1234', AUTH_TOKEN: '2345' }, { rules: 'mockRules' }, mockCallback);
+    await handler(mockContext, { rules: 'mockRules' }, mockCallback);
 
     expect(mockCallback).toHaveBeenCalledWith(null, {
       body: {
@@ -72,7 +69,7 @@ describe('the recordingrules function', () => {
   it('should return a "missing rules" error when the rules array is absent', async () => {
     const mockCallback = jest.fn();
 
-    await handler({ ACCOUNT_SID: '1234', AUTH_TOKEN: '2345' }, { room_sid: 'mockSid' }, mockCallback);
+    await handler(mockContext, { room_sid: 'mockSid' }, mockCallback);
 
     expect(mockCallback).toHaveBeenCalledWith(null, {
       body: {


### PR DESCRIPTION
<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

This PR updates the recording rules function so that it uses the twilio client that is returned by `context.getTwilioClient()`, instead of importing its own version with `require`. 

It turns out, that the version of the twilio client returned by `getTwilioClient()` is determined by the `twilio` version specified in the package.json file that is used for deploying the functions (which can be found [here](https://github.com/twilio-labs/plugin-rtc/blob/master/src/helpers.js#L215)). So it was never necessary to `require('twilio')` in order to get a version of the twilio client that had support for the recording rules API. 